### PR TITLE
Issue #137 - ctools update

### DIFF
--- a/ding_event.make
+++ b/ding_event.make
@@ -42,7 +42,7 @@ projects[cs_adaptive_image][subdir] = "contrib"
 projects[cs_adaptive_image][version] = "1.0"
 
 projects[ctools][subdir] = "contrib"
-projects[ctools][version] = "1.4"
+projects[ctools][version] = "1.5"
 
 projects[date][subdir] = "contrib"
 projects[date][version] = "2.8"


### PR DESCRIPTION
Updated ctools which fixes PHP 5.3 warnings.