### PR TITLE
Issue 510: Remove empty text from group events list

### DIFF
--- a/ding_event.views_default.inc
+++ b/ding_event.views_default.inc
@@ -738,6 +738,7 @@ function ding_event_views_default_views() {
   $handler->display->display_options['row_plugin'] = 'fields';
   $handler->display->display_options['row_options']['default_field_elements'] = FALSE;
   $handler->display->display_options['defaults']['row_options'] = FALSE;
+  $handler->display->display_options['defaults']['empty'] = FALSE;
   $handler->display->display_options['defaults']['relationships'] = FALSE;
   /* Relationship: OG membership: OG membership from Node */
   $handler->display->display_options['relationships']['og_membership_rel']['id'] = 'og_membership_rel';

--- a/ding_event.views_default.inc
+++ b/ding_event.views_default.inc
@@ -1230,14 +1230,6 @@ function ding_event_views_default_views() {
   $handler->display->display_options['row_options']['default_field_elements'] = FALSE;
   $handler->display->display_options['defaults']['row_options'] = FALSE;
   $handler->display->display_options['defaults']['empty'] = FALSE;
-  /* No results behavior: Global: Text area */
-  $handler->display->display_options['empty']['area']['id'] = 'area';
-  $handler->display->display_options['empty']['area']['table'] = 'views';
-  $handler->display->display_options['empty']['area']['field'] = 'area';
-  $handler->display->display_options['empty']['area']['label'] = 'Empty text';
-  $handler->display->display_options['empty']['area']['empty'] = TRUE;
-  $handler->display->display_options['empty']['area']['content'] = 'No events where found in the group.';
-  $handler->display->display_options['empty']['area']['format'] = 'ding_wysiwyg';
   $handler->display->display_options['defaults']['relationships'] = FALSE;
   /* Relationship: OG membership group */
   $handler->display->display_options['relationships']['og_membership_rel']['id'] = 'og_membership_rel';
@@ -2321,7 +2313,6 @@ function ding_event_views_default_views() {
     t('Event list (library)'),
     t('Groups event list'),
     t('Group events'),
-    t('No events where found in the group.'),
     t('OG membership group'),
     t('OG group'),
     t('OG membership from node (Library)'),


### PR DESCRIPTION
This prevents the view from appearing if there is no events for the group and we can allow news to use the full width.

Issue: http://platform.dandigbib.org/issues/510

This is necessary for ding2/ddbasic#6 to work.