### PR TITLE
Enhancement #687 - Event without libraries

### DIFF
--- a/ding_event.info
+++ b/ding_event.info
@@ -95,3 +95,4 @@ features[variable][] = scheduler_publish_enable_ding_event
 features[variable][] = scheduler_publish_touch_ding_event
 features[variable][] = scheduler_unpublish_enable_ding_event
 features[views_view][] = ding_event
+mtime = 1436271790

--- a/ding_event.module
+++ b/ding_event.module
@@ -158,6 +158,16 @@ function ding_event_install_menu_position($op = 'install') {
   }
 }
 
+function ding_event_views_query_alter(&$view, &$query) {
+  if ($view->name == 'ding_event' && $view->current_display == 'ding_event_groups_list') {
+    $query->table_queue['og_membership_node_1']['join']->extra[] = array(
+      'field' => 'gid',
+      'value' => reset($views->args),
+      'operator' => '<>',
+    );
+  }
+}
+
 /**
  * Implements hook_views_pre_execute().
  *

--- a/ding_event.module
+++ b/ding_event.module
@@ -158,8 +158,15 @@ function ding_event_install_menu_position($op = 'install') {
   }
 }
 
+/**
+ * Implements hook_views_query_alter().
+ *
+ * To retrieve a list of events that may or may not have a library connection,
+ * we need to do a conditional left join.
+ */
 function ding_event_views_query_alter(&$view, &$query) {
   if ($view->name == 'ding_event' && $view->current_display == 'ding_event_groups_list') {
+    // Don't include the group itself, as this will result in duplicates.
     $query->table_queue['og_membership_node_1']['join']->extra[] = array(
       'field' => 'gid',
       'value' => reset($views->args),

--- a/ding_event.views_default.inc
+++ b/ding_event.views_default.inc
@@ -1320,6 +1320,7 @@ function ding_event_views_default_views() {
   $handler->display->display_options['fields']['title_1']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['title_1']['element_wrapper_type'] = '0';
   $handler->display->display_options['fields']['title_1']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['title_1']['hide_empty'] = TRUE;
   /* Field: Location */
   $handler->display->display_options['fields']['field_ding_event_location']['id'] = 'field_ding_event_location';
   $handler->display->display_options['fields']['field_ding_event_location']['table'] = 'field_data_field_ding_event_location';
@@ -1423,14 +1424,6 @@ function ding_event_views_default_views() {
   $handler->display->display_options['filters']['date_filter']['date_fields'] = array(
     'field_data_field_ding_event_date.field_ding_event_date_value' => 'field_data_field_ding_event_date.field_ding_event_date_value',
     'field_data_field_ding_event_date.field_ding_event_date_value2' => 'field_data_field_ding_event_date.field_ding_event_date_value2',
-  );
-  /* Filter criterion: Content: Type */
-  $handler->display->display_options['filters']['type_1']['id'] = 'type_1';
-  $handler->display->display_options['filters']['type_1']['table'] = 'node';
-  $handler->display->display_options['filters']['type_1']['field'] = 'type';
-  $handler->display->display_options['filters']['type_1']['relationship'] = 'og_membership_related_node_group_1';
-  $handler->display->display_options['filters']['type_1']['value'] = array(
-    'ding_library' => 'ding_library',
   );
   $handler->display->display_options['pane_category']['name'] = 'Groups panes';
   $handler->display->display_options['pane_category']['weight'] = '0';


### PR DESCRIPTION
This allows events for a group to be listed, even if the event is not connected to a library.

Basically, the ding_library condition has been moved from the where-clause, to a conditional on a left-join.
