### PR TITLE
Issue 1319: Adjust event-display to news-display

### DIFF
--- a/ding_event.views_default.inc
+++ b/ding_event.views_default.inc
@@ -706,12 +706,13 @@ function ding_event_views_default_views() {
   /* Display: Library event list */
   $handler = $view->new_display('panel_pane', 'Library event list', 'ding_event_library_list');
   $handler->display->display_options['defaults']['use_more'] = FALSE;
+  $handler->display->display_options['use_more'] = TRUE;
   $handler->display->display_options['defaults']['link_display'] = FALSE;
   $handler->display->display_options['link_display'] = 'custom_url';
-  $handler->display->display_options['link_url'] = 'arrangementer';
+  $handler->display->display_options['link_url'] = 'bibliotek/!1/arrangementer';
   $handler->display->display_options['defaults']['pager'] = FALSE;
-  $handler->display->display_options['pager']['type'] = 'full';
-  $handler->display->display_options['pager']['options']['items_per_page'] = '10';
+  $handler->display->display_options['pager']['type'] = 'some';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '5';
   $handler->display->display_options['pager']['options']['offset'] = '0';
   $handler->display->display_options['pager']['options']['id'] = '0';
   $handler->display->display_options['pager']['options']['expose']['items_per_page_label'] = 'Number of elements';


### PR DESCRIPTION
Display only five items, introduce more-link that redirects to local library's events